### PR TITLE
✨: add new option print

### DIFF
--- a/convmoji/commit.py
+++ b/convmoji/commit.py
@@ -23,6 +23,7 @@ helpers = {
         --co-authored-by '<User user@no-reply> '\
         --co-authored-by '<User2 user2@no-reply>'",
     "debug": "Debug mode (does not execute commit)",
+    "print": "Print the commit message (does not execute commit)",
     "info": "Prompt convmoji info (does not execute commit)",
     "version": "Prompt convmoji version (does not execute commit)",
 }
@@ -96,6 +97,7 @@ def commit(
         help=helpers["co-authored-by"],
     ),
     debug: bool = typer.Option(False, "--debug", help=helpers["debug"]),
+    print_message: bool = typer.Option(False, "--print", help=helpers["print"]),
     info: typing.Optional[bool] = typer.Option(  # noqa: U100
         None,
         "--info",
@@ -124,6 +126,8 @@ def commit(
     )
     if debug:
         typer.echo(repr(cmd))
+    elif print_message:
+        typer.echo(cmd.message_formatter())
     else:
         os.system(repr(cmd))  # pragma: no cover
 

--- a/convmoji/commit_types.py
+++ b/convmoji/commit_types.py
@@ -47,7 +47,7 @@ class CommitCmd(BaseModel):
     no_verify: typing.Optional[bool]
     co_authored_by: typing.Optional[typing.List[str]]
 
-    def _message_formatter(self):
+    def message_formatter(self):
         message = self.description
         if self.body:
             message += f"\n\n{self.body}"
@@ -62,15 +62,18 @@ class CommitCmd(BaseModel):
                     [f"Co-authored-by: {author}" for author in self.co_authored_by]
                 ),
             )
-        return message
+        if self.breaking_changes:
+            self.type = f"{self.type}‼️"
+
+        if self.scope == "":
+            return f"{self.type}: {message}"
+
+        return f"{self.type}({self.scope}): {message}"
 
     def __repr__(self):
         optional_args = ""
         optional_args += "--amend " if self.amend else ""
         optional_args += "--no-verify " if self.no_verify else ""
-        if self.breaking_changes:
-            self.type = f"{self.type}‼️"
-        message = self._message_formatter()
-        if self.scope == "":
-            return f'{commit_cmd_base} "{self.type}: {message}" {optional_args}'
-        return f'{commit_cmd_base} "{self.type}({self.scope}): {message}" {optional_args}'
+
+        message = self.message_formatter()
+        return f'{commit_cmd_base} "{message}" {optional_args}'

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -235,3 +235,9 @@ def test_app_commit_info_007():
 def test_app_commit_version_008():
     result = invoke_app_commit("--version")
     assert f"{__name__} {__version__}" in result.stdout
+
+def test_print_message(default_description: str):
+    result = invoke_app_commit(default_description, "--print")
+    assert f"✨: {default_description}\n\n" == result.stdout
+
+


### PR DESCRIPTION
prints only the commit-message without any git-command or options